### PR TITLE
Track app semver images in production registry

### DIFF
--- a/charts/api/Chart.yaml
+++ b/charts/api/Chart.yaml
@@ -21,7 +21,7 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.53.3"
+appVersion: "1.56.3"
 
 dependencies:
   # - name: minio

--- a/charts/api/Chart.yaml
+++ b/charts/api/Chart.yaml
@@ -21,7 +21,7 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.16.0"
+appVersion: "1.53.3"
 
 dependencies:
   # - name: minio

--- a/charts/api/values.yaml
+++ b/charts/api/values.yaml
@@ -5,10 +5,8 @@
 replicaCount: 1
 
 image:
-  repository: gcr.io/rungalileo-dev/api
+  repository: gcr.io/rungalileo-prod/api
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: latest
 
 imagePullSecrets:
   - name: galileo-docker-registry-secret

--- a/charts/comet/Chart.yaml
+++ b/charts/comet/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.16.0"
+appVersion: "0.2.5"

--- a/charts/comet/values.yaml
+++ b/charts/comet/values.yaml
@@ -5,10 +5,8 @@
 replicaCount: 1
 
 image:
-  repository: gcr.io/rungalileo-dev/comet
+  repository: gcr.io/rungalileo-prod/comet
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: latest
 
 imagePullSecrets:
   - name: galileo-docker-registry-secret

--- a/charts/model-server/Chart.yaml
+++ b/charts/model-server/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.16.0"
+appVersion: "0.1.7"

--- a/charts/model-server/values.yaml
+++ b/charts/model-server/values.yaml
@@ -5,10 +5,8 @@
 replicaCount: 1
 
 image:
-  repository: gcr.io/rungalileo-dev/model-server
+  repository: gcr.io/rungalileo-prod/model-server
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: latest
 
 imagePullSecrets:
   - name: galileo-docker-registry-secret

--- a/charts/runners/Chart.yaml
+++ b/charts/runners/Chart.yaml
@@ -21,7 +21,7 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.16.0"
+appVersion: "1.38.0"
 
 # dependencies:
 #   - name: minio

--- a/charts/runners/values.yaml
+++ b/charts/runners/values.yaml
@@ -25,9 +25,8 @@ runnerDeployments:
 replicaCount: 1
 
 image:
-  repository: gcr.io/rungalileo-dev/runners
+  repository: gcr.io/rungalileo-prod/runners
   pullPolicy: IfNotPresent
-  tag: latest
 
 imagePullSecrets:
   - name: galileo-docker-registry-secret

--- a/charts/ui/Chart.yaml
+++ b/charts/ui/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.16.0"
+appVersion: "2.1.82"

--- a/charts/ui/values.yaml
+++ b/charts/ui/values.yaml
@@ -5,10 +5,8 @@
 replicaCount: 1
 
 image:
-  repository: gcr.io/rungalileo-dev/ui
+  repository: gcr.io/rungalileo-prod/ui
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: latest
 
 imagePullSecrets:
   - name: galileo-docker-registry-secret


### PR DESCRIPTION
# Description

Since this Helm chart is beginning to see use by customers, we want them to use tested and validated images in our production registry for each application.

# Testing

Successfully deployed a fresh install of the Helm charts to https://console.helm-test.rungalileo.io/

Validated all images are tracking the correct version from the correct registry.
