### PR TITLE
Update template to allow direct usage of S3 and RDS

### DIFF
--- a/charts/api/templates/deployment.yaml
+++ b/charts/api/templates/deployment.yaml
@@ -41,12 +41,12 @@ spec:
             - "-c"
             - |
               set -ex
-              echo "Checking readiness of primary Postgres..."
-              while ! pg_isready -h postgres-rw.{{ .Release.Namespace }}.svc.cluster.local; do
-                echo "postgres-rw is not ready yet, sleeping for 10 seconds..."
+              echo "Checking readiness of primary Postgres DB..."
+              while ! pg_isready -h {{.Values.postgres.write.host}}; do
+                echo "Postgres DB is not ready yet, sleeping for 10 seconds..."
                 sleep 10
               done
-              echo "postgres-rw is ready."
+              echo "Postgres DB is ready."
 
               echo "Checking readiness of Minio client..."
               while [ $(curl -sw '%{http_code}' "http://minio-client.{{ .Release.Namespace }}.svc.cluster.local:9000/minio/health/ready" -o /dev/null) -ne 200 ]; do
@@ -84,17 +84,17 @@ spec:
                   name: postgres-app
                   key: password
             - name: GALILEO_DATABASE_URL_WRITE
-              value: "postgresql://$(GALILEO_DATABASE_USER):$(GALILEO_DATABASE_PASSWORD)@postgres-rw.{{ .Release.Namespace }}.svc.cluster.local:5432/$(GALILEO_DATABASE_NAME)"
+              value: "postgresql://$(GALILEO_DATABASE_USER):$(GALILEO_DATABASE_PASSWORD)@{{.Values.postgres.write.host}}:{{.Values.postgres.write.port}}/$(GALILEO_DATABASE_NAME)"
             - name: GALILEO_DATABASE_URL_READ
-              value: "postgresql://$(GALILEO_DATABASE_USER):$(GALILEO_DATABASE_PASSWORD)@postgres-rw.{{ .Release.Namespace }}.svc.cluster.local:5432/$(GALILEO_DATABASE_NAME)"
-            - name: GALILEO_MINIO_ENDPOINT_URL
-              value: "http://minio.{{ .Release.Namespace }}.svc.cluster.local:9000"
-            - name: GALILEO_MINIO_K8S_SVC_ADDR
-              value: "http://minio.{{ .Release.Namespace }}.svc.cluster.local:9000"
-            - name: GALILEO_MINIO_FQDN
-              value: "minio.{{ .Release.Namespace }}.svc.cluster.local:9000"
+              value: "postgresql://$(GALILEO_DATABASE_USER):$(GALILEO_DATABASE_PASSWORD)@{{.Values.postgres.read.host}}:{{.Values.postgres.read.port}}/$(GALILEO_DATABASE_NAME)"
             - name: GALILEO_MINIO_REGION
-              value: "us-east-1"
+              value: {{ .Values.cloud.region }}
+            - name: GALILEO_MINIO_FQDN
+              value: {{ if eq .Values.cloud.vendor "s3" }}"s3.amazonaws.com"{{ else if eq .Values.cloud.vendor "gs" }}"storage.googleapis.com"{{ else }}{{ .Values.cloud.endpointURL | trimSuffix ":9000" }}{{ end }}
+            - name: GALILEO_MINIO_ENDPOINT_URL
+              value: {{ .Values.cloud.endpointURL }}
+            - name: GALILEO_MINIO_K8S_SVC_ADDR
+              value: {{ .Values.cloud.endpointURL }}
             - name: GALILEO_MINIO_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
@@ -157,17 +157,19 @@ spec:
                   name: postgres-app
                   key: password
             - name: GALILEO_DATABASE_URL_WRITE
-              value: "postgresql://$(GALILEO_DATABASE_USER):$(GALILEO_DATABASE_PASSWORD)@postgres-rw.{{ .Release.Namespace }}.svc.cluster.local:5432/$(GALILEO_DATABASE_NAME)"
+              value: "postgresql://$(GALILEO_DATABASE_USER):$(GALILEO_DATABASE_PASSWORD)@{{.Values.postgres.write.host}}:{{.Values.postgres.write.port}}/$(GALILEO_DATABASE_NAME)"
             - name: GALILEO_DATABASE_URL_READ
-              value: "postgresql://$(GALILEO_DATABASE_USER):$(GALILEO_DATABASE_PASSWORD)@postgres-rw.{{ .Release.Namespace }}.svc.cluster.local:5432/$(GALILEO_DATABASE_NAME)"
-            - name: GALILEO_MINIO_ENDPOINT_URL
-              value: "http://minio.{{ .Release.Namespace }}.svc.cluster.local:9000"
-            - name: GALILEO_MINIO_K8S_SVC_ADDR
-              value: "http://minio.{{ .Release.Namespace }}.svc.cluster.local:9000"
-            - name: GALILEO_MINIO_FQDN
-              value: "minio.{{ .Release.Namespace }}.svc.cluster.local:9000"
+              value: "postgresql://$(GALILEO_DATABASE_USER):$(GALILEO_DATABASE_PASSWORD)@{{.Values.postgres.read.host}}:{{.Values.postgres.read.port}}/$(GALILEO_DATABASE_NAME)"
+            # - name: CLOUD_VENDOR_OBJECTSTORE
+            #   value: {{ .Values.cloud.vendor }}
             - name: GALILEO_MINIO_REGION
-              value: "us-east-1"
+              value: {{ .Values.cloud.region }}
+            - name: GALILEO_MINIO_FQDN
+              value: {{ if eq .Values.cloud.vendor "s3" }}"s3.amazonaws.com"{{ else if eq .Values.cloud.vendor "gs" }}"storage.googleapis.com"{{ else }}{{ .Values.cloud.endpointURL | trimSuffix ":9000" }}{{ end }}
+            - name: GALILEO_MINIO_ENDPOINT_URL
+              value: {{ .Values.cloud.endpointURL }}
+            - name: GALILEO_MINIO_K8S_SVC_ADDR
+              value: {{ .Values.cloud.endpointURL }}
             - name: GALILEO_MINIO_ACCESS_KEY
               valueFrom:
                 secretKeyRef:

--- a/charts/api/values.yaml
+++ b/charts/api/values.yaml
@@ -105,50 +105,18 @@ env: {}
   # GALILEO_RUNNERS_SVC_NAME: "runners-hs.galileo.svc.cluster.local"
   # GALILEO_RUNNERS_SVC_PORT: "50052"
 
-# MinIO configuration: https://github.com/minio/minio/blob/master/helm/minio/values.yaml
-minio:
-  replicas: 2 # 2 is the minimum
-  resources:
-  requests:
-    memory: 1Gi
-  buckets:
-    - name: galileo-auto-datasets
-      policy: none
-      purge: false
-      versioning: false
-      objectlocking: false
-    - name: galileo-images
-      policy: none
-      purge: false
-      versioning: false
-      objectlocking: false
-    - name: galileo-models
-      policy: none
-      purge: false
-      versioning: false
-      objectlocking: false
-    - name: galileo-project-runs
-      policy: none
-      purge: false
-      versioning: false
-      objectlocking: false
-    - name: galileo-project-runs-results
-      policy: none
-      purge: false
-      versioning: false
-      objectlocking: false
-    - name: galileo-prompts-datasets
-      policy: none
-      purge: false
-      versioning: false
-      objectlocking: false
-    - name: galileo-prompts-results
-      policy: none
-      purge: false
-      versioning: false
-      objectlocking: false
+cloud:
+  vendor: "minio"  # default to minio, can be overridden to s3, gs, exoscale, etc.
+  region: "us-east-1"
+  endpointURL: "http://minio.galileo.svc.cluster.local:9000"
 
 postgres:
+  write:
+    host: "postgres-rw.galileo.svc.cluster.local"
+    port: 5432
+  read:
+    host: "postgres-rw.galileo.svc.cluster.local"
+    port: 5432
   clusterName: "postgres"
   instances: 2
   primaryUpdateStrategy: "supervised"

--- a/charts/api/values.yaml
+++ b/charts/api/values.yaml
@@ -115,7 +115,7 @@ postgres:
     host: "postgres-rw.galileo.svc.cluster.local"
     port: 5432
   read:
-    host: "postgres-rw.galileo.svc.cluster.local"
+    host: "postgres-r.galileo.svc.cluster.local"
     port: 5432
   clusterName: "postgres"
   instances: 2

--- a/charts/galileo/Chart.lock
+++ b/charts/galileo/Chart.lock
@@ -26,5 +26,5 @@ dependencies:
 - name: rabbitmq-cluster-operator
   repository: https://charts.bitnami.com/bitnami
   version: 3.15.4
-digest: sha256:83022c1273bf859fb4061e8bfb20e89450b347f223f390769102d58972d1693f
-generated: "2024-02-20T10:42:17.634917-06:00"
+digest: sha256:d17f81b59755debb3a8efe62afbac0c5f02009c47516be073c2f1ea520be73d3
+generated: "2024-02-26T15:40:10.653016-06:00"

--- a/charts/runners/templates/deployment.yaml
+++ b/charts/runners/templates/deployment.yaml
@@ -87,14 +87,14 @@ spec:
                 secretKeyRef:
                   name: api-secret
                   key: GALILEO_API_SECRET_KEY
-            - name: GALILEO_MINIO_ENDPOINT_URL
-              value: "http://minio.{{ $.Release.Namespace }}.svc.cluster.local:9000"
-            - name: GALILEO_MINIO_K8S_SVC_ADDR
-              value: "http://minio.{{ $.Release.Namespace }}.svc.cluster.local:9000"
-            - name: GALILEO_MINIO_FQDN
-              value: "minio.{{ $.Release.Namespace }}.svc.cluster.local:9000"
             - name: GALILEO_MINIO_REGION
-              value: "us-east-1"
+              value: {{ $.Values.cloud.region }}
+            - name: GALILEO_MINIO_FQDN
+              value: {{ if eq $.Values.cloud.vendor "s3" }}"s3.amazonaws.com"{{ else if eq $.Values.cloud.vendor "gs" }}"storage.googleapis.com"{{ else }}{{ $.Values.cloud.endpointURL | trimSuffix ":9000" }}{{ end }}
+            - name: GALILEO_MINIO_ENDPOINT_URL
+              value: {{ $.Values.cloud.endpointURL }}
+            - name: GALILEO_MINIO_K8S_SVC_ADDR
+              value: {{ $.Values.cloud.endpointURL }}
             - name: GALILEO_MINIO_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
@@ -105,6 +105,12 @@ spec:
                 secretKeyRef:
                   name: minio-secret
                   key: rootPassword
+            {{- with $.Values.env }}
+            {{- range $key, $value := . }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- end }}
           livenessProbe:
             exec:
               command:

--- a/charts/runners/values.yaml
+++ b/charts/runners/values.yaml
@@ -117,45 +117,7 @@ tolerations: []
 
 affinity: {}
 
-# MinIO configuration: https://github.com/minio/minio/blob/master/helm/minio/values.yaml
-minio:
-  replicas: 2 # 2 is the minimum
-  resources:
-  requests:
-    memory: 1Gi
-  buckets:
-    - name: galileo-auto-datasets
-      policy: none
-      purge: false
-      versioning: false
-      objectlocking: false
-    - name: galileo-images
-      policy: none
-      purge: false
-      versioning: false
-      objectlocking: false
-    - name: galileo-models
-      policy: none
-      purge: false
-      versioning: false
-      objectlocking: false
-    - name: galileo-project-runs
-      policy: none
-      purge: false
-      versioning: false
-      objectlocking: false
-    - name: galileo-project-runs-results
-      policy: none
-      purge: false
-      versioning: false
-      objectlocking: false
-    - name: galileo-prompts-datasets
-      policy: none
-      purge: false
-      versioning: false
-      objectlocking: false
-    - name: galileo-prompts-results
-      policy: none
-      purge: false
-      versioning: false
-      objectlocking: false
+cloud:
+  vendor: "minio"  # default to minio, can be overridden to s3, gs, exoscale, etc.
+  region: "us-east-1"
+  endpointURL: "http://minio.galileo.svc.cluster.local:9000"

--- a/examples/galileo-aws-resources.yaml
+++ b/examples/galileo-aws-resources.yaml
@@ -1,0 +1,86 @@
+# API configuration
+api:
+  cloud:
+    vendor: "s3"
+    region: "us-east-2"
+    endpointURL: "https://s3.amazonaws.com"
+  postgres:
+    write:
+      host: "postgres.c2k7aajpjf0n.us-east-2.rds.amazonaws.com"
+      port: 5432
+    read:
+      host: "postgres.c2k7aajpjf0n.us-east-2.rds.amazonaws.com"
+      port: 5432
+  env:
+    GALILEO_CONSOLE_URL: "https://console.helm-test.rungalileo.io"
+    GALILEO_ROOT_BUCKET_NAME: "galileo-helm-test-project-runs"
+    GALILEO_ROOT_BUCKET_NAME_RESULTS: "galileo-helm-test-project-runs-results"
+    GALILEO_IMAGES_BUCKET_NAME: "galileo-helm-test-images"
+    GALILEO_PROMPTS_BUCKET_NAME: "galileo-helm-test-prompts"
+    GALILEO_PROMPTS_DATASETS_BUCKET_NAME: "galileo-helm-test-prompts-datasets"
+    GALILEO_PROMPTS_RESULTS_BUCKET_NAME: "galileo-helm-test-prompts-results"
+    GALILEO_MODELS_BUCKET_NAME: "galileo-helm-test-models"
+    GALILEO_AUTO_DATASETS_BUCKET_NAME: "galileo-helm-test-auto-datasets"
+  ingress:
+    annotations:
+      kubernetes.io/ingress.class: "alb"
+      alb.ingress.kubernetes.io/scheme: internet-facing
+      alb.ingress.kubernetes.io/target-type: ip
+      alb.ingress.kubernetes.io/group.name: galileo
+      alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-2:818240400754:certificate/8708a742-58cf-4159-b77b-fb3430f7619a
+      alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
+    hosts:
+      - host: api.helm-test.rungalileo.io
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - hosts:
+          - api.helm-test.rungalileo.io
+        secretName: api-tls
+
+runners:
+  cloud:
+    vendor: "s3"
+    region: "us-east-2"
+    endpointURL: "https://s3.amazonaws.com"
+  env:
+    GALILEO_ROOT_BUCKET_NAME: "galileo-helm-test-project-runs"
+    GALILEO_ROOT_BUCKET_NAME_RESULTS: "galileo-helm-test-project-runs-results"
+    GALILEO_IMAGES_BUCKET_NAME: "galileo-helm-test-images"
+    GALILEO_PROMPTS_BUCKET_NAME: "galileo-helm-test-prompts"
+    GALILEO_PROMPTS_DATASETS_BUCKET_NAME: "galileo-helm-test-prompts-datasets"
+    GALILEO_PROMPTS_RESULTS_BUCKET_NAME: "galileo-helm-test-prompts-results"
+    GALILEO_MODELS_BUCKET_NAME: "galileo-helm-test-models"
+    GALILEO_AUTO_DATASETS_BUCKET_NAME: "galileo-helm-test-auto-datasets"
+
+# UI configuration
+ui:
+  env:
+    NEXT_PUBLIC_API_URL: "http://api.helm-test.rungalileo.io"
+    NEXTAUTH_URL: "http://console.helm-test.rungalileo.io"
+  ingress:
+    annotations:
+      kubernetes.io/ingress.class: "alb"
+      alb.ingress.kubernetes.io/scheme: internet-facing
+      alb.ingress.kubernetes.io/target-type: ip
+      alb.ingress.kubernetes.io/group.name: galileo
+      alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-2:818240400754:certificate/fa38169e-5e36-4838-a657-af78c06c81c0
+      alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
+    hosts:
+      - host: console.helm-test.rungalileo.io
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - hosts:
+          - console.helm-test.rungalileo.io
+        secretName: ui-tls
+
+# CloudNative PG configuration: https://github.com/cloudnative-pg/charts/blob/main/charts/cloudnative-pg/values.yaml
+cloudnative-pg:
+  enabled: false
+
+# MinIO configuration: https://github.com/minio/minio/blob/master/helm/minio/values.yaml
+minio:
+  enabled: false


### PR DESCRIPTION
# Description

These changes will allow customers to better specify the resources they want to use for storage.  An example Helm values file is added to demonstrate this usage with S3 and RDS for usage in AWS.

# Testing

Did a manual E2E test using RDS and S3.

https://console.helm-test.rungalileo.io/prompt/8906b6e6-5f09-4303-ac45-f3601935bdae/create-run?runId=f68d6ec8-196b-4150-9689-e09d11935d21&datasetId=484f97f5-38a3-4cae-8b24-7c039196c09e&sortBy=id&templateId=1fe3d69c-934d-4c3a-8eed-eccbe040905d&templateVersionId=a5ccdbb0-f921-434c-85a7-b9177f3450a9