### PR TITLE
Add Prometheus as a dependency

### DIFF
--- a/charts/galileo/Chart.lock
+++ b/charts/galileo/Chart.lock
@@ -29,5 +29,8 @@ dependencies:
 - name: clickhouse
   repository: https://charts.bitnami.com/bitnami
   version: 6.2.3
-digest: sha256:ccd2f2877d407019bd9dc1e7a1b604400eca2e9bbe5da180350373e086ef2d20
-generated: "2024-06-06T10:36:12.192785-05:00"
+- name: prometheus
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 25.21.0
+digest: sha256:665a522a786c984e5171f3b100c6440ff8b0ba7d294b89ea57ebec886b450d5c
+generated: "2024-06-07T11:11:06.091803-05:00"

--- a/charts/galileo/Chart.yaml
+++ b/charts/galileo/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.6.0
 
 dependencies:
   - name: api
@@ -53,3 +53,7 @@ dependencies:
     version: "6.2.3"
     repository: "https://charts.bitnami.com/bitnami"
     condition: clickhouse.enabled
+  - name: prometheus
+    version: "25.21.0"
+    repository: "https://prometheus-community.github.io/helm-charts"
+    condition: prometheus.enabled

--- a/charts/galileo/values.yaml
+++ b/charts/galileo/values.yaml
@@ -189,31 +189,198 @@ prometheus:
     enabled: true
   prometheusSpec:
     additionalScrapeConfigs:
+      - job_name: 'node-exporter'
+        kubernetes_sd_configs:
+          - role: endpoints
+        relabel_configs:
+        - source_labels: [__meta_kubernetes_endpoints_name]
+          regex: 'node-exporter'
+          action: keep
+      - job_name: 'kubernetes-apiservers'
+        kubernetes_sd_configs:
+        - role: endpoints
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        relabel_configs:
+        - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+          action: keep
+          regex: default;kubernetes;https
+      - job_name: 'kubernetes-nodes'
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        kubernetes_sd_configs:
+        - role: node
+        relabel_configs:
+        - action: labelmap
+          regex: __meta_kubernetes_node_label_(.+)
+        - target_label: __address__
+          replacement: kubernetes.default.svc:443
+        - source_labels: [__meta_kubernetes_node_name]
+          regex: (.+)
+          target_label: __metrics_path__
+          replacement: /api/v1/nodes/${1}/proxy/metrics
+      - job_name: 'kube-state-metrics'
+        static_configs:
+          - targets: ['galileo-kube-state-metrics.galileo.svc.cluster.local:8080']
+      - job_name: 'kubernetes-cadvisor'
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        kubernetes_sd_configs:
+        - role: node
+        relabel_configs:
+        - action: labelmap
+          regex: __meta_kubernetes_node_label_(.+)
+        - target_label: __address__
+          replacement: kubernetes.default.svc:443
+        - source_labels: [__meta_kubernetes_node_name]
+          regex: (.+)
+          target_label: __metrics_path__
+          replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+      - job_name: 'kubernetes-service-endpoints'
+        kubernetes_sd_configs:
+        - role: endpoints
+        relabel_configs:
+        - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
+          action: keep
+          regex: true
+        - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+          action: replace
+          target_label: __scheme__
+          regex: (https?)
+        - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+          action: replace
+          target_label: __metrics_path__
+          regex: (.+)
+        - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+          action: replace
+          target_label: __address__
+          regex: ([^:]+)(?::\d+)?;(\d+)
+          replacement: $1:$2
+        - action: labelmap
+          regex: __meta_kubernetes_service_label_(.+)
+        - source_labels: [__meta_kubernetes_namespace]
+          action: replace
+          target_label: kubernetes_namespace
+        - source_labels: [__meta_kubernetes_service_name]
+          action: replace
+          target_label: kubernetes_name
       - job_name: 'kubernetes-pods'
+        # API has high cardinality, so we scrape less frequently.
         scrape_interval: 2m
         kubernetes_sd_configs:
-          - role: pod
+        - role: pod
         relabel_configs:
-          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
-            action: keep
-            regex: true
-          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
-            action: replace
-            target_label: __metrics_path__
-            regex: (.+)
-          - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
-            action: replace
-            regex: ([^:]+)(?::\d+)?;(\d+)
-            replacement: $1:$2
-            target_label: __address__
-          - action: labelmap
-            regex: __meta_kubernetes_pod_label_(.+)
-          - source_labels: [__meta_kubernetes_namespace]
-            action: replace
-            target_label: kubernetes_namespace
-          - source_labels: [__meta_kubernetes_pod_name]
-            action: replace
-            target_label: kubernetes_pod_name
+        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+          action: keep
+          regex: true
+        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+          action: replace
+          target_label: __metrics_path__
+          regex: (.+)
+        - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+          action: replace
+          regex: ([^:]+)(?::\d+)?;(\d+)
+          replacement: $1:$2
+          target_label: __address__
+        - action: labelmap
+          regex: __meta_kubernetes_pod_label_(.+)
+        - source_labels: [__meta_kubernetes_namespace]
+          action: replace
+          target_label: kubernetes_namespace
+        - source_labels: [__meta_kubernetes_pod_name]
+          action: replace
+          target_label: kubernetes_pod_name
+      # Copied from https://github.com/rabbitmq/cluster-operator/blob/main/observability/prometheus/config-file.yml#L26C1-L111C27
+      - job_name: rabbitmq-http
+        honor_timestamps: true
+        metrics_path: /metrics
+        scheme: http
+        follow_redirects: true
+        relabel_configs:
+        - source_labels: [job]
+          separator: ;
+          regex: (.*)
+          target_label: __tmp_prometheus_job_name
+          replacement: $1
+          action: replace
+        - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_component]
+          separator: ;
+          regex: rabbitmq
+          replacement: $1
+          action: keep
+        - source_labels: [__meta_kubernetes_endpoint_port_name]
+          separator: ;
+          regex: prometheus
+          replacement: $1
+          action: keep
+        - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
+          separator: ;
+          regex: Node;(.*)
+          target_label: node
+          replacement: ${1}
+          action: replace
+        - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
+          separator: ;
+          regex: Pod;(.*)
+          target_label: pod
+          replacement: ${1}
+          action: replace
+        - source_labels: [__meta_kubernetes_namespace]
+          separator: ;
+          regex: (.*)
+          target_label: namespace
+          replacement: $1
+          action: replace
+        - source_labels: [__meta_kubernetes_service_name]
+          separator: ;
+          regex: (.*)
+          target_label: service
+          replacement: $1
+          action: replace
+        - source_labels: [__meta_kubernetes_pod_name]
+          separator: ;
+          regex: (.*)
+          target_label: pod
+          replacement: $1
+          action: replace
+        - source_labels: [__meta_kubernetes_pod_container_name]
+          separator: ;
+          regex: (.*)
+          target_label: container
+          replacement: $1
+          action: replace
+        - source_labels: [__meta_kubernetes_service_name]
+          separator: ;
+          regex: (.*)
+          target_label: job
+          replacement: ${1}
+          action: replace
+        - separator: ;
+          regex: (.*)
+          target_label: endpoint
+          replacement: prometheus
+          action: replace
+        - source_labels: [__address__]
+          separator: ;
+          regex: (.*)
+          modulus: 1
+          target_label: __tmp_hash
+          replacement: $1
+          action: hashmod
+        - source_labels: [__tmp_hash]
+          separator: ;
+          regex: "0"
+          replacement: $1
+          action: keep
+        kubernetes_sd_configs:
+        - role: endpoints
+          follow_redirects: true
     remoteWrite:
       - url: https://prometheus-prod-36-prod-us-west-0.grafana.net/api/prom/push
         basic_auth:

--- a/charts/galileo/values.yaml
+++ b/charts/galileo/values.yaml
@@ -175,3 +175,63 @@ rabbitmq-cluster-operator:
 clickhouse:
   enabled: true
   fullnameOverride: "clickhouse"
+  zookeeper:
+    fullnameOverride: "zookeeper"
+
+# Prometheus configuration: https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus/values.yaml
+prometheus:
+  enabled: true
+  replicaCount: 2
+  serviceAccount:
+    create: false
+    name: galileo
+  alertmanager:
+    enabled: true
+  prometheusSpec:
+    additionalScrapeConfigs:
+      - job_name: 'kubernetes-pods'
+        scrape_interval: 2m
+        kubernetes_sd_configs:
+          - role: pod
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+            action: keep
+            regex: true
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+            action: replace
+            target_label: __metrics_path__
+            regex: (.+)
+          - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+            action: replace
+            regex: ([^:]+)(?::\d+)?;(\d+)
+            replacement: $1:$2
+            target_label: __address__
+          - action: labelmap
+            regex: __meta_kubernetes_pod_label_(.+)
+          - source_labels: [__meta_kubernetes_namespace]
+            action: replace
+            target_label: kubernetes_namespace
+          - source_labels: [__meta_kubernetes_pod_name]
+            action: replace
+            target_label: kubernetes_pod_name
+    remoteWrite:
+      - url: https://prometheus-prod-36-prod-us-west-0.grafana.net/api/prom/push
+        basic_auth:
+          username: ""
+          password: ""
+        write_relabel_configs:
+          - source_labels: [__name__]
+            regex: '^(api_|galileo_|job_|rabbitmq_queue_|nv_inference_|nv_gpu_|nv_cpu_).*'
+            action: keep
+          - source_labels: [queue]
+            regex: '^(health|fast|normal|slow|$)'
+            action: keep
+    storageSpec:
+      volumeClaimTemplate:
+        spec:
+          accessModes: ["ReadWriteOnce"]
+          resources:
+            requests:
+              storage: 50Gi
+  kubeStateMetrics:
+    enabled: true


### PR DESCRIPTION
# Description

Driving parity with our previous Kubernetes deployment manifests.

# Testing

```bash
➜  helm-charts git:(tyler/prometheus-dependency) ✗ kubectl get pods                               
NAME                                                    READY   STATUS    RESTARTS        AGE
api-86d76cb74-6c96c                                     1/1     Running   0               12m
clickhouse-shard0-0                                     1/1     Running   0               12m
clickhouse-shard0-1                                     1/1     Running   0               12m
clickhouse-shard0-2                                     1/1     Running   0               12m
clickhouse-shard1-0                                     1/1     Running   0               12m
clickhouse-shard1-1                                     1/1     Running   0               12m
clickhouse-shard1-2                                     1/1     Running   0               12m
cloudnative-pg-c98497bbc-hqwlc                          1/1     Running   2 (12m ago)     12m
comet-5ff59bcdc5-7x697                                  1/1     Running   0               12m
galileo-alertmanager-0                                  1/1     Running   0               12m
galileo-kube-state-metrics-75c587dfcb-5ng97             1/1     Running   0               12m
galileo-prometheus-node-exporter-4496r                  1/1     Running   0               12m
galileo-prometheus-node-exporter-r4drv                  1/1     Running   0               12m
galileo-prometheus-node-exporter-z97vm                  1/1     Running   0               12m
galileo-prometheus-pushgateway-7b688dd4b4-fcrjj         1/1     Running   0               12m
galileo-prometheus-server-74fdfb77c5-trfcs              2/2     Running   0               12m
minio-0                                                 1/1     Running   0               12m
minio-1                                                 1/1     Running   0               12m
postgres-1                                              1/1     Running   0               11m
postgres-2                                              1/1     Running   0               10m
rabbitmq-cluster-operator-94778958b-jcbfk               1/1     Running   0               12m
rabbitmq-cluster-server-0                               1/1     Running   0               12m
rabbitmq-cluster-server-1                               1/1     Running   0               12m
rabbitmq-messaging-topology-operator-57655fdb5b-gxnl5   1/1     Running   0               12m
runners-6fcd677478-qqmpn                                1/1     Running   0               12m
runners-large-b6d99b7b6-6sf57                           1/1     Running   0               12m
runners-small-76d9795956-8q4sq                          1/1     Running   0               12m
ui-78c6cf86b-jxfq8                                      0/1     Running   2 (2m23s ago)   12m
wizard-7cb77bbdb8-jv5pb                                 1/1     Running   0               12m
zookeeper-0                                             1/1     Running   0               12m
zookeeper-1                                             1/1     Running   0               12m
zookeeper-2                                             1/1     Running   0               12m
```

(UI failures expected as I didn't hook up the CNAMEs for DNS.)