### PR TITLE
Add Prometheus community Helm repository to GitHub action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
           helm repo add minio https://charts.min.io/
           helm repo add cloudnative-pg https://cloudnative-pg.github.io/charts
           helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
           helm repo update
 
       - name: Run chart-releaser


### PR DESCRIPTION
This will fix [the failing GH action](https://github.com/rungalileo/helm-charts/actions/runs/9420962622/job/25954079275)