### PR TITLE
Add Prometheus Adapter as a dependency

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,0 +1,10 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    uses: rungalileo/.github/.github/workflows/pre-commit.yaml@main

--- a/charts/galileo/Chart.lock
+++ b/charts/galileo/Chart.lock
@@ -32,5 +32,8 @@ dependencies:
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
   version: 25.21.0
-digest: sha256:665a522a786c984e5171f3b100c6440ff8b0ba7d294b89ea57ebec886b450d5c
-generated: "2024-06-07T11:11:06.091803-05:00"
+- name: prometheus-adapter
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 4.10.0
+digest: sha256:8ad753486b46b036c2131cfdc5819f9044bd6b196a03212374454b05ad29c178
+generated: "2024-06-10T10:22:14.03301-05:00"

--- a/charts/galileo/Chart.yaml
+++ b/charts/galileo/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.7.0
 
 dependencies:
   - name: api
@@ -57,3 +57,7 @@ dependencies:
     version: "25.21.0"
     repository: "https://prometheus-community.github.io/helm-charts"
     condition: prometheus.enabled
+  - name: prometheus-adapter
+    version: "4.10.0"
+    repository: "https://prometheus-community.github.io/helm-charts"
+    condition: prometheus-adapter.enabled

--- a/charts/galileo/values.yaml
+++ b/charts/galileo/values.yaml
@@ -402,3 +402,51 @@ prometheus:
               storage: 50Gi
   kubeStateMetrics:
     enabled: true
+
+# Prometheus Adapter configuration: https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus-adapter/values.yaml
+prometheus-adapter:
+  enabled: true
+  fullnameOverride: "prometheus-adapter"
+  rules:
+    default: false
+    custom:
+      - seriesQuery: 'rabbitmq_queue_messages{namespace!="",service!=""}'
+        resources:
+          overrides:
+            namespace:
+              resource: "namespace"
+            service:
+              resource: "service"
+        name:
+          as: "fast_queue_job_consumer_ratio"
+        metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>,queue="fast"}) by (<<.GroupBy>>) / sum(rabbitmq_queue_consumers{<<.LabelMatchers>>,queue="fast"}+0.01) by (<<.GroupBy>>)
+      - seriesQuery: 'rabbitmq_queue_messages{namespace!="",service!=""}'
+        resources:
+          overrides:
+            namespace:
+              resource: "namespace"
+            service:
+              resource: "service"
+        name:
+          as: "normal_queue_job_consumer_ratio"
+        metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>,queue="normal"}) by (<<.GroupBy>>) / sum(rabbitmq_queue_consumers{<<.LabelMatchers>>,queue="normal"}+0.01) by (<<.GroupBy>>)
+      - seriesQuery: 'rabbitmq_queue_messages{namespace!="",service!=""}'
+        resources:
+          overrides:
+            namespace:
+              resource: "namespace"
+            service:
+              resource: "service"
+        name:
+          as: "slow_queue_job_consumer_ratio"
+        metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>,queue="slow"}) by (<<.GroupBy>>) / sum(rabbitmq_queue_consumers{<<.LabelMatchers>>,queue="slow"}+0.01) by (<<.GroupBy>>)
+  resources:
+    limits:
+      cpu: 50m
+      memory: 128Mi
+    requests:
+      cpu: 50m
+      memory: 128Mi
+  serviceAccount:
+    create: true
+    name: "prometheus-adapter"


### PR DESCRIPTION
Continuing to drive parity with our Kubernetes manifest deployments, this PR adds Prometheus Adapter as a dependency.

I also added a pre-commit GitHub action to automate checks on PRs and merges.