### PR TITLE
Enable HPAs for API, Runners, and Wizard; supporting metric changes

### DIFF
--- a/charts/api/Chart.yaml
+++ b/charts/api/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/api/values.yaml
+++ b/charts/api/values.yaml
@@ -25,7 +25,9 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
-podAnnotations: {}
+podAnnotations:
+  prometheus.io/scrape: "true"
+  prometheus.io/port: "8088"
 podLabels: {}
 
 podSecurityContext: {}
@@ -59,23 +61,19 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+resources:
+  limits:
+    cpu: 500m
+    memory: 2Gi
+  requests:
+    cpu: 100m
+    memory: 1Gi
 
 autoscaling:
-  enabled: false
-  minReplicas: 1
-  maxReplicas: 100
-  targetCPUUtilizationPercentage: 80
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
   # targetMemoryUtilizationPercentage: 80
 
 # Additional volumes on the output Deployment definition.

--- a/charts/galileo/Chart.lock
+++ b/charts/galileo/Chart.lock
@@ -1,16 +1,16 @@
 dependencies:
 - name: api
   repository: file://../api
-  version: 0.5.0
+  version: 0.6.0
 - name: comet
   repository: file://../comet
   version: 0.3.0
 - name: wizard
   repository: file://../wizard
-  version: 0.3.0
+  version: 0.4.0
 - name: runners
   repository: file://../runners
-  version: 0.4.0
+  version: 0.5.0
 - name: ui
   repository: file://../ui
   version: 0.5.0
@@ -29,11 +29,17 @@ dependencies:
 - name: clickhouse
   repository: https://charts.bitnami.com/bitnami
   version: 6.2.3
+- name: metrics-server
+  repository: https://kubernetes-sigs.github.io/metrics-server/
+  version: 3.12.1
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
   version: 25.21.0
+- name: prometheus-operator-crds
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 12.0.0
 - name: prometheus-adapter
   repository: https://prometheus-community.github.io/helm-charts
   version: 4.10.0
-digest: sha256:8ad753486b46b036c2131cfdc5819f9044bd6b196a03212374454b05ad29c178
-generated: "2024-06-10T10:22:14.03301-05:00"
+digest: sha256:dadefcbd9f8b0a5d126b324f436c7ba7caa3a68cb829267952a406290ccdd9ea
+generated: "2024-06-12T12:02:09.560929-05:00"

--- a/charts/galileo/Chart.yaml
+++ b/charts/galileo/Chart.yaml
@@ -15,21 +15,21 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.0
+version: 0.8.0
 
 dependencies:
   - name: api
-    version: "0.5.0"
+    version: "0.6.0"
     repository: "file://../api"
   - name: comet
     version: "0.3.0"
     repository: "file://../comet"
   - name: wizard
-    version: "0.3.0"
+    version: "0.4.0"
     repository: "file://../wizard"
     condition: wizard.enabled
   - name: runners
-    version: "0.4.0"
+    version: "0.5.0"
     repository: "file://../runners"
   - name: ui
     version: "0.5.0"
@@ -53,8 +53,16 @@ dependencies:
     version: "6.2.3"
     repository: "https://charts.bitnami.com/bitnami"
     condition: clickhouse.enabled
+  - name: metrics-server
+    version: "3.12.1"
+    repository: "https://kubernetes-sigs.github.io/metrics-server/"
+    condition: metrics-server.enabled
   - name: prometheus
     version: "25.21.0"
+    repository: "https://prometheus-community.github.io/helm-charts"
+    condition: prometheus.enabled
+  - name: prometheus-operator-crds
+    version: "12.0.0"
     repository: "https://prometheus-community.github.io/helm-charts"
     condition: prometheus.enabled
   - name: prometheus-adapter

--- a/charts/galileo/values.yaml
+++ b/charts/galileo/values.yaml
@@ -163,6 +163,13 @@ rabbitmq-cluster-operator:
   fullnameOverride: "rabbitmq-cluster-operator"
   msgTopologyOperator:
     fullnameOverride: "rabbitmq-messaging-topology-operator"
+    metrics:
+      service:
+        enabled: true
+      serviceMonitor:
+        enabled: true
+      podMonitor:
+        enabled: true
     resources:
       limits:
         cpu: 1000m
@@ -178,209 +185,17 @@ clickhouse:
   zookeeper:
     fullnameOverride: "zookeeper"
 
+# Metrics Server configuration: https://github.com/kubernetes-sigs/metrics-server/blob/master/charts/metrics-server/values.yaml
+metrics-server:
+  enabled: true
+
 # Prometheus configuration: https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus/values.yaml
 prometheus:
   enabled: true
-  replicaCount: 2
-  serviceAccount:
-    create: false
-    name: galileo
   alertmanager:
     enabled: true
-  prometheusSpec:
-    additionalScrapeConfigs:
-      - job_name: 'node-exporter'
-        kubernetes_sd_configs:
-          - role: endpoints
-        relabel_configs:
-        - source_labels: [__meta_kubernetes_endpoints_name]
-          regex: 'node-exporter'
-          action: keep
-      - job_name: 'kubernetes-apiservers'
-        kubernetes_sd_configs:
-        - role: endpoints
-        scheme: https
-        tls_config:
-          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-        relabel_configs:
-        - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
-          action: keep
-          regex: default;kubernetes;https
-      - job_name: 'kubernetes-nodes'
-        scheme: https
-        tls_config:
-          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-        kubernetes_sd_configs:
-        - role: node
-        relabel_configs:
-        - action: labelmap
-          regex: __meta_kubernetes_node_label_(.+)
-        - target_label: __address__
-          replacement: kubernetes.default.svc:443
-        - source_labels: [__meta_kubernetes_node_name]
-          regex: (.+)
-          target_label: __metrics_path__
-          replacement: /api/v1/nodes/${1}/proxy/metrics
-      - job_name: 'kube-state-metrics'
-        static_configs:
-          - targets: ['galileo-kube-state-metrics.galileo.svc.cluster.local:8080']
-      - job_name: 'kubernetes-cadvisor'
-        scheme: https
-        tls_config:
-          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-        kubernetes_sd_configs:
-        - role: node
-        relabel_configs:
-        - action: labelmap
-          regex: __meta_kubernetes_node_label_(.+)
-        - target_label: __address__
-          replacement: kubernetes.default.svc:443
-        - source_labels: [__meta_kubernetes_node_name]
-          regex: (.+)
-          target_label: __metrics_path__
-          replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
-      - job_name: 'kubernetes-service-endpoints'
-        kubernetes_sd_configs:
-        - role: endpoints
-        relabel_configs:
-        - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
-          action: keep
-          regex: true
-        - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
-          action: replace
-          target_label: __scheme__
-          regex: (https?)
-        - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
-          action: replace
-          target_label: __metrics_path__
-          regex: (.+)
-        - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
-          action: replace
-          target_label: __address__
-          regex: ([^:]+)(?::\d+)?;(\d+)
-          replacement: $1:$2
-        - action: labelmap
-          regex: __meta_kubernetes_service_label_(.+)
-        - source_labels: [__meta_kubernetes_namespace]
-          action: replace
-          target_label: kubernetes_namespace
-        - source_labels: [__meta_kubernetes_service_name]
-          action: replace
-          target_label: kubernetes_name
-      - job_name: 'kubernetes-pods'
-        # API has high cardinality, so we scrape less frequently.
-        scrape_interval: 2m
-        kubernetes_sd_configs:
-        - role: pod
-        relabel_configs:
-        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
-          action: keep
-          regex: true
-        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
-          action: replace
-          target_label: __metrics_path__
-          regex: (.+)
-        - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
-          action: replace
-          regex: ([^:]+)(?::\d+)?;(\d+)
-          replacement: $1:$2
-          target_label: __address__
-        - action: labelmap
-          regex: __meta_kubernetes_pod_label_(.+)
-        - source_labels: [__meta_kubernetes_namespace]
-          action: replace
-          target_label: kubernetes_namespace
-        - source_labels: [__meta_kubernetes_pod_name]
-          action: replace
-          target_label: kubernetes_pod_name
-      # Copied from https://github.com/rabbitmq/cluster-operator/blob/main/observability/prometheus/config-file.yml#L26C1-L111C27
-      - job_name: rabbitmq-http
-        honor_timestamps: true
-        metrics_path: /metrics
-        scheme: http
-        follow_redirects: true
-        relabel_configs:
-        - source_labels: [job]
-          separator: ;
-          regex: (.*)
-          target_label: __tmp_prometheus_job_name
-          replacement: $1
-          action: replace
-        - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_component]
-          separator: ;
-          regex: rabbitmq
-          replacement: $1
-          action: keep
-        - source_labels: [__meta_kubernetes_endpoint_port_name]
-          separator: ;
-          regex: prometheus
-          replacement: $1
-          action: keep
-        - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
-          separator: ;
-          regex: Node;(.*)
-          target_label: node
-          replacement: ${1}
-          action: replace
-        - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
-          separator: ;
-          regex: Pod;(.*)
-          target_label: pod
-          replacement: ${1}
-          action: replace
-        - source_labels: [__meta_kubernetes_namespace]
-          separator: ;
-          regex: (.*)
-          target_label: namespace
-          replacement: $1
-          action: replace
-        - source_labels: [__meta_kubernetes_service_name]
-          separator: ;
-          regex: (.*)
-          target_label: service
-          replacement: $1
-          action: replace
-        - source_labels: [__meta_kubernetes_pod_name]
-          separator: ;
-          regex: (.*)
-          target_label: pod
-          replacement: $1
-          action: replace
-        - source_labels: [__meta_kubernetes_pod_container_name]
-          separator: ;
-          regex: (.*)
-          target_label: container
-          replacement: $1
-          action: replace
-        - source_labels: [__meta_kubernetes_service_name]
-          separator: ;
-          regex: (.*)
-          target_label: job
-          replacement: ${1}
-          action: replace
-        - separator: ;
-          regex: (.*)
-          target_label: endpoint
-          replacement: prometheus
-          action: replace
-        - source_labels: [__address__]
-          separator: ;
-          regex: (.*)
-          modulus: 1
-          target_label: __tmp_hash
-          replacement: $1
-          action: hashmod
-        - source_labels: [__tmp_hash]
-          separator: ;
-          regex: "0"
-          replacement: $1
-          action: keep
-        kubernetes_sd_configs:
-        - role: endpoints
-          follow_redirects: true
+  server:
+    replicaCount: 1
     remoteWrite:
       - url: https://prometheus-prod-36-prod-us-west-0.grafana.net/api/prom/push
         basic_auth:
@@ -393,22 +208,216 @@ prometheus:
           - source_labels: [queue]
             regex: '^(health|fast|normal|slow|$)'
             action: keep
-    storageSpec:
-      volumeClaimTemplate:
-        spec:
-          accessModes: ["ReadWriteOnce"]
-          resources:
-            requests:
-              storage: 50Gi
-  kubeStateMetrics:
-    enabled: true
+  serverFiles:
+    prometheus.yml:
+      scrape_configs:
+        - job_name: 'node-exporter'
+          kubernetes_sd_configs:
+            - role: endpoints
+          relabel_configs:
+            - source_labels: [__meta_kubernetes_endpoints_name]
+              regex: 'node-exporter'
+              action: keep
+        - job_name: 'kubernetes-apiservers'
+          kubernetes_sd_configs:
+            - role: endpoints
+          scheme: https
+          tls_config:
+            ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          relabel_configs:
+            - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+              action: keep
+              regex: default;kubernetes;https
+        - job_name: 'kubernetes-nodes'
+          scheme: https
+          tls_config:
+            ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          kubernetes_sd_configs:
+            - role: node
+          relabel_configs:
+            - action: labelmap
+              regex: __meta_kubernetes_node_label_(.+)
+            - target_label: __address__
+              replacement: kubernetes.default.svc:443
+            - source_labels: [__meta_kubernetes_node_name]
+              regex: (.+)
+              target_label: __metrics_path__
+              replacement: /api/v1/nodes/${1}/proxy/metrics
+        - job_name: 'kube-state-metrics'
+          static_configs:
+            - targets: ['galileo-kube-state-metrics.galileo.svc.cluster.local:8080']
+        - job_name: 'kubernetes-cadvisor'
+          scheme: https
+          tls_config:
+            ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          kubernetes_sd_configs:
+            - role: node
+          relabel_configs:
+            - action: labelmap
+              regex: __meta_kubernetes_node_label_(.+)
+            - target_label: __address__
+              replacement: kubernetes.default.svc:443
+            - source_labels: [__meta_kubernetes_node_name]
+              regex: (.+)
+              target_label: __metrics_path__
+              replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+        - job_name: 'kubernetes-service-endpoints'
+          kubernetes_sd_configs:
+            - role: endpoints
+          relabel_configs:
+            - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
+              action: keep
+              regex: true
+            - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+              action: replace
+              target_label: __scheme__
+              regex: (https?)
+            - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+              action: replace
+              target_label: __metrics_path__
+              regex: (.+)
+            - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+              action: replace
+              target_label: __address__
+              regex: ([^:]+)(?::\d+)?;(\d+)
+              replacement: $1:$2
+            - action: labelmap
+              regex: __meta_kubernetes_service_label_(.+)
+            - source_labels: [__meta_kubernetes_namespace]
+              action: replace
+              target_label: kubernetes_namespace
+            - source_labels: [__meta_kubernetes_service_name]
+              action: replace
+              target_label: kubernetes_name
+        - job_name: 'kubernetes-pods'
+          # API has high cardinality, so we scrape less frequently.
+          scrape_interval: 2m
+          kubernetes_sd_configs:
+            - role: pod
+          relabel_configs:
+            - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+              action: keep
+              regex: true
+            - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+              action: replace
+              target_label: __metrics_path__
+              regex: (.+)
+            - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+              action: replace
+              regex: ([^:]+)(?::\d+)?;(\d+)
+              replacement: $1:$2
+              target_label: __address__
+            - action: labelmap
+              regex: __meta_kubernetes_pod_label_(.+)
+            - source_labels: [__meta_kubernetes_namespace]
+              action: replace
+              target_label: kubernetes_namespace
+            - source_labels: [__meta_kubernetes_pod_name]
+              action: replace
+              target_label: kubernetes_pod_name
+        - job_name: 'rabbitmq-http'
+          honor_timestamps: true
+          metrics_path: /metrics
+          scheme: http
+          follow_redirects: true
+          relabel_configs:
+            - source_labels: [job]
+              separator: ;
+              regex: (.*)
+              target_label: __tmp_prometheus_job_name
+              replacement: $1
+              action: replace
+            - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_component]
+              separator: ;
+              regex: rabbitmq
+              replacement: $1
+              action: keep
+            - source_labels: [__meta_kubernetes_endpoint_port_name]
+              separator: ;
+              regex: prometheus
+              replacement: $1
+              action: keep
+            - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
+              separator: ;
+              regex: Node;(.*)
+              target_label: node
+              replacement: ${1}
+              action: replace
+            - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
+              separator: ;
+              regex: Pod;(.*)
+              target_label: pod
+              replacement: ${1}
+              action: replace
+            - source_labels: [__meta_kubernetes_namespace]
+              separator: ;
+              regex: (.*)
+              target_label: namespace
+              replacement: $1
+              action: replace
+            - source_labels: [__meta_kubernetes_service_name]
+              separator: ;
+              regex: (.*)
+              target_label: service
+              replacement: $1
+              action: replace
+            - source_labels: [__meta_kubernetes_pod_name]
+              separator: ;
+              regex: (.*)
+              target_label: pod
+              replacement: $1
+              action: replace
+            - source_labels: [__meta_kubernetes_pod_container_name]
+              separator: ;
+              regex: (.*)
+              target_label: container
+              replacement: $1
+              action: replace
+            - source_labels: [__meta_kubernetes_service_name]
+              separator: ;
+              regex: (.*)
+              target_label: job
+              replacement: ${1}
+              action: replace
+            - separator: ;
+              regex: (.*)
+              target_label: endpoint
+              replacement: prometheus
+              action: replace
+            - source_labels: [__address__]
+              separator: ;
+              regex: (.*)
+              modulus: 1
+              target_label: __tmp_hash
+              replacement: $1
+              action: hashmod
+            - source_labels: [__tmp_hash]
+              separator: ;
+              regex: "0"
+              replacement: $1
+              action: keep
+          kubernetes_sd_configs:
+            - role: endpoints
+              follow_redirects: true
 
 # Prometheus Adapter configuration: https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus-adapter/values.yaml
 prometheus-adapter:
   enabled: true
   fullnameOverride: "prometheus-adapter"
+  prometheus:
+    url: http://galileo-prometheus-server.galileo.svc
+    port: 80
+  resources:
+    limits:
+      cpu: 200m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 256Mi
   rules:
-    default: false
     custom:
       - seriesQuery: 'rabbitmq_queue_messages{namespace!="",service!=""}'
         resources:
@@ -440,13 +449,13 @@ prometheus-adapter:
         name:
           as: "slow_queue_job_consumer_ratio"
         metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>,queue="slow"}) by (<<.GroupBy>>) / sum(rabbitmq_queue_consumers{<<.LabelMatchers>>,queue="slow"}+0.01) by (<<.GroupBy>>)
-  resources:
-    limits:
-      cpu: 50m
-      memory: 128Mi
-    requests:
-      cpu: 50m
-      memory: 128Mi
-  serviceAccount:
-    create: true
-    name: "prometheus-adapter"
+      - seriesQuery: 'nv_gpu_utilization{kubernetes_namespace!=""}'
+        resources:
+          overrides:
+            kubernetes_namespace:
+              resource: "namespace"
+            kubernetes_pod_name:
+              resource: "pod"
+        name:
+          as: "gpu_utilization"
+        metricsQuery: 'avg(nv_gpu_utilization{<<.LabelMatchers>>}) by (kubernetes_namespace, kubernetes_pod_name)'

--- a/charts/runners/Chart.yaml
+++ b/charts/runners/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/runners/templates/hpa.yaml
+++ b/charts/runners/templates/hpa.yaml
@@ -1,32 +1,46 @@
-{{- if .Values.autoscaling.enabled }}
+{{- $root := . -}}
+{{- range .Values.runnerDeployments }}
+{{- if $root.Values.autoscaling.enabled }}
+---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "runners.fullname" . }}
+  name: {{ .name }}
   labels:
-    {{- include "runners.labels" . | nindent 4 }}
+    {{- include "runners.labels" $ | nindent 4 }}
 spec:
+  behavior:
+    scaleUp:
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 60
+      selectPolicy: Max
+      stabilizationWindowSeconds: 200
+    scaleDown:
+      policies:
+        - type: Percent
+          value: 20
+          periodSeconds: 60
+      selectPolicy: Max
+      stabilizationWindowSeconds: 600
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "runners.fullname" . }}
-  minReplicas: {{ .Values.autoscaling.minReplicas }}
-  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+    name: {{ .name }}
+  minReplicas: {{ $root.Values.autoscaling.minReplicas }}
+  maxReplicas: {{ $root.Values.autoscaling.maxReplicas }}
   metrics:
-    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: cpu
+    - type: Object
+      object:
+        metric:
+          name: {{ .hpa_metric_name }}
+        describedObject:
+          apiVersion: v1
+          kind: Service
+          name: rabbitmq-cluster
         target:
-          type: Utilization
-          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
-    {{- end }}
-    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: memory
-        target:
-          type: Utilization
-          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
-    {{- end }}
+          type: Value
+          value: {{ .concurrency }}
+{{- end }}
 {{- end }}

--- a/charts/runners/values.yaml
+++ b/charts/runners/values.yaml
@@ -7,20 +7,29 @@ runnerDeployments:
     queues: "health,fast,normal"
     pool: "processes"
     cpu_request: 1000m
+    cpu_limit: 1500m
     concurrency: 5
-    memory_request: 2Gi
+    memory_request: 3Gi
+    memory_limit: 4Gi
+    hpa_metric_name: "normal_queue_job_consumer_ratio"
   - name: "runners-small"
     queues: "health,fast"
     pool: "processes"
     cpu_request: 512m
+    cpu_limit: 768m
     concurrency: 2
-    memory_request: 1Gi
+    memory_request: 1.5Gi
+    memory_limit: 2Gi
+    hpa_metric_name: "fast_queue_job_consumer_ratio"
   - name: "runners-large"
-    queues: "health,fast,slow"
+    queues: "health,slow"
     pool: "processes"
     concurrency: 2
-    cpu_request: 2000m
-    memory_request: 4Gi
+    cpu_request: 1000m
+    cpu_limit: 1500m
+    memory_request: 6Gi
+    memory_limit: 8Gi
+    hpa_metric_name: "slow_queue_job_consumer_ratio"
 
 replicaCount: 1
 
@@ -92,11 +101,11 @@ resources: {}
   #   memory: 128Mi
 
 autoscaling:
-  enabled: false
+  enabled: true
   minReplicas: 1
-  maxReplicas: 100
-  targetCPUUtilizationPercentage: 80
-  # targetMemoryUtilizationPercentage: 80
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 80
 
 # Additional volumes on the output Deployment definition.
 volumes: []

--- a/charts/wizard/Chart.yaml
+++ b/charts/wizard/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/wizard/templates/deployment.yaml
+++ b/charts/wizard/templates/deployment.yaml
@@ -38,7 +38,13 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: {{ .Values.service.port }}
+              containerPort: 8000
+              protocol: TCP
+            - name: grpc
+              containerPort: 8001
+              protocol: TCP
+            - name: metrics
+              containerPort: 8002
               protocol: TCP
           env:
             - name: GALILEO_CUSTOMER_NAME

--- a/charts/wizard/templates/hpa.yaml
+++ b/charts/wizard/templates/hpa.yaml
@@ -6,6 +6,21 @@ metadata:
   labels:
     {{- include "wizard.labels" . | nindent 4 }}
 spec:
+  behavior:
+    scaleUp:
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 15
+      selectPolicy: Max
+      stabilizationWindowSeconds: 60
+    scaleDown:
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 60
+      selectPolicy: Max
+      stabilizationWindowSeconds: 600
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
@@ -13,20 +28,28 @@ spec:
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:
-    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
-    {{- end }}
-    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: memory
-        target:
-          type: Utilization
-          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
-    {{- end }}
+  {{- if .Values.useGPU }}
+  - type: Pods
+    pods:
+      metric:
+        name: gpu_utilization
+      target:
+        type: AverageValue
+        averageValue: "0.8"
+  {{- else }}
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+  {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/wizard/templates/service.yaml
+++ b/charts/wizard/templates/service.yaml
@@ -7,9 +7,14 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.service.port }}
-      targetPort: http
-      protocol: TCP
-      name: http
+  - name: http
+    port: 8000
+    targetPort: http
+  - name: grpc
+    port: 8001
+    targetPort: grpc
+  - name: metrics
+    port: 8002
+    targetPort: metrics
   selector:
     {{- include "wizard.selectorLabels" . | nindent 4 }}

--- a/charts/wizard/values.yaml
+++ b/charts/wizard/values.yaml
@@ -3,8 +3,8 @@
 # Declare variables to be passed into your templates.
 
 customer_name: "default"
-
 replicaCount: 1
+useGPU: false
 
 image:
   repository: gcr.io/rungalileo-prod/wizard
@@ -27,7 +27,9 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
-podAnnotations: {}
+podAnnotations:
+  prometheus.io/scrape: "true"
+  prometheus.io/port: "8002"
 podLabels: {}
 
 podSecurityContext: {}
@@ -61,22 +63,18 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+resources:
+  requests:
+    cpu: 6000m
+    memory: 24Gi
+  limits:
+    cpu: 8000m
+    memory: 32Gi
 
 autoscaling:
-  enabled: false
+  enabled: true
   minReplicas: 1
-  maxReplicas: 100
+  maxReplicas: 30
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 


### PR DESCRIPTION
# Description

This change will enable the Horizontal Pod Autoscaling, and gets the metrics into a state more at parity with our existing clusters.

In getting HPAs working, a lot of gaps were discovered with how the current Helm charts were working with Prometheus metrics.  A lot of debugging and adding on some missing components, the HPAs are now able to scale with their expected metrics (some custom, some from [metrics server](https://github.com/kubernetes-sigs/metrics-server))

# Testing

```console
➜  helm-charts git:(tyler/hpa) ✗ kubectl get hpa
NAME            REFERENCE                  TARGETS   MINPODS   MAXPODS   REPLICAS   AGE
api             Deployment/api             4%/70%    2         5         2          22h
runners         Deployment/runners         0/5       1         5         1          22h
runners-large   Deployment/runners-large   0/2       1         5         1          22h
runners-small   Deployment/runners-small   0/2       1         5         1          22h
wizard          Deployment/wizard          0%/80%    1         30        1          22h
```