### PR TITLE
Add metric server Helm repo to GH action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
           helm repo add cloudnative-pg https://cloudnative-pg.github.io/charts
           helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+          helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/
           helm repo update
 
       - name: Run chart-releaser


### PR DESCRIPTION
Forgot to add this in https://github.com/rungalileo/helm-charts/pull/10, needed to [fix the release workflow](https://github.com/rungalileo/helm-charts/actions/runs/9501748984/job/26188042998)